### PR TITLE
feat: publish core API to npm

### DIFF
--- a/.github/workflows/publish_action.yaml
+++ b/.github/workflows/publish_action.yaml
@@ -187,3 +187,38 @@ jobs:
         with:
           personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
           skip_checkout: "true"
+
+  publish-npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: bump-version
+    if: github.actor == github.repository_owner && github.ref == 'refs/heads/main'
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.bump-version.outputs.current-version }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build library
+        run: pnpm build:lib
+
+      - name: Smoke test
+        run: node scripts/smoke-core-package.mjs
+
+      - name: Publish to npm
+        run: pnpm publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ Version bumping:
 - Local `.changeset/*` files are intentionally gitignored. Do not commit them.
 - Verify runtime behavior in ComfyUI before changing adapter logic or making claims about ComfyUI APIs.
 - `src/core.ts` is the public library entrypoint. It must stay free of ComfyUI-specific imports such as `index.ts`, `adapter.ts`, `runtime.ts`, `settings.ts`, `debug.ts`, `bounds.ts`, or `utils.ts`.
-- Library output is emitted to `lib/` by `pnpm build:lib` / `tsc -p tsconfig.lib.json`. The `prepare` script runs that build automatically for GitHub dependency consumers.
+- Library output is emitted to `lib/` by `pnpm build:lib` / `tsc -p tsconfig.lib.json`. The `prepare` script runs that build automatically on install.
+- The npm package exports `"."` → `lib/core.js`. There is no `./core` subpath.
 
 ## Runtime Facts
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Add tokens to group titles to control how nodes are arranged:
 - `pnpm test`
 - `pnpm build`
 - `pnpm build:lib` emits the pure library entrypoint to `lib/`
-- `pnpm test:lib` smoke-tests the built `comfyui-node-organizer/core` export
+- `pnpm test:lib` smoke-tests the built `comfyui-node-organizer` npm export
 - `pnpm setup:e2e` provisions a dedicated ComfyUI instance for browser tests and installs the exact workflow-template package required by the pinned ComfyUI checkout
 - `pnpm test:e2e` runs the full Playwright suite against that instance
 - Broad installed-template coverage is discovered live at E2E runtime from the pinned test ComfyUI environment, with one correctness-invariant test per installed workflow template
@@ -65,7 +65,15 @@ Visual regression baselines are platform-specific: committed snapshots use `-win
 
 Most users can ignore this section. The extension works entirely inside ComfyUI.
 
-`comfyui-node-organizer/core` exists for developers who want to reuse the layout engine outside ComfyUI, for example in a script, service, test harness, or workflow conversion tool.
+The package is published to npm as `comfyui-node-organizer` for developers who want to reuse the layout engine outside ComfyUI, for example in a script, service, test harness, or workflow conversion tool.
+
+```bash
+npm install comfyui-node-organizer
+```
+
+```ts
+import { normalizeWorkflowGeometry, inferGroupMembership } from "comfyui-node-organizer";
+```
 
 It exposes a small pure API:
 - `normalizeWorkflowGeometry(...)` lays out plain workflow data and returns absolute node and group rectangles
@@ -73,7 +81,7 @@ It exposes a small pure API:
 
 In practice: if you want "organize this workflow JSON the same way the extension would" without loading ComfyUI, this is the entrypoint.
 
-Build it with `pnpm build:lib`. `pnpm test:lib` verifies that the built `comfyui-node-organizer/core` package can be imported by Node.
+Build it locally with `pnpm build:lib`. `pnpm test:lib` verifies that the built package can be imported by Node.
 
 ### Local CI
 

--- a/package.json
+++ b/package.json
@@ -3,15 +3,19 @@
   "version": "2.1.0",
   "description": "ComfyUI extension to organize nodes",
   "type": "module",
+  "main": "./lib/core.js",
+  "module": "./lib/core.js",
+  "types": "./lib/core.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js"
-    },
-    "./core": {
       "import": "./lib/core.js",
       "types": "./lib/core.d.ts"
     }
   },
+  "files": [
+    "lib/",
+    "README.md"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -40,12 +44,10 @@
   "author": "PBandDev",
   "license": "AGPL-3.0",
   "packageManager": "pnpm@10.17.1",
-  "dependencies": {
-    "typescript": "^5.9.3",
-    "vite": "^7.1.12"
-  },
   "devDependencies": {
     "@comfyorg/comfyui-frontend-types": "^1.32.1",
+    "typescript": "^5.9.3",
+    "vite": "^7.1.12",
     "@playwright/test": "^1.58.2",
     "@types/node": "^24.10.0",
     "@vitest/coverage-v8": "^4.0.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,13 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
-      vite:
-        specifier: ^7.1.12
-        version: 7.3.0(@types/node@24.10.4)(tsx@4.21.0)
     devDependencies:
       '@comfyorg/comfyui-frontend-types':
         specifier: ^1.32.1
@@ -33,6 +26,12 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.1.12
+        version: 7.3.0(@types/node@24.10.4)(tsx@4.21.0)
       vitest:
         specifier: ^4.0.16
         version: 4.0.16(@types/node@24.10.4)(tsx@4.21.0)

--- a/scripts/smoke-core-package.mjs
+++ b/scripts/smoke-core-package.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-const coreModule = await import("comfyui-node-organizer/core");
+const coreModule = await import("comfyui-node-organizer");
 
 assert.equal(typeof coreModule.inferGroupMembership, "function");
 assert.equal(typeof coreModule.normalizeWorkflowGeometry, "function");


### PR DESCRIPTION
## Summary

- Remap `exports` so `"."` points at `lib/core.js` (drop `./core` subpath)
- Add `main`/`module`/`types` fallback fields for older tooling
- Move `typescript`/`vite` to `devDependencies` (zero runtime deps)
- Add `files` field to limit tarball to `lib/` + `README.md`
- Add parallel `publish-npm` job in publish workflow using `NPM_TOKEN` secret
- Update smoke test, README, and AGENTS.md to reflect bare import path

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 197 tests pass
- [x] `pnpm test:lib` — smoke test passes with bare `comfyui-node-organizer` import
- [x] Verify `NPM_TOKEN` secret is set (confirmed via `gh secret list`)
- [ ] First real publish on next release dispatch